### PR TITLE
Boston Housing example based on Pytorch instead of tensorflow/swift

### DIFF
--- a/Examples/Regression-BostonHousing/main.fsx
+++ b/Examples/Regression-BostonHousing/main.fsx
@@ -77,7 +77,7 @@ for epoch in 1..epochCount do
 
         optimizer.update(&model, along=grad)
         
-        let logits = model.forward(dataset.xTrain.[batchStart..batchEnd-1])
+        let logits = model(dataset.xTrain.[batchStart..batchEnd-1])
         epochMAE <- epochMAE + meanAbsoluteError(logits, dataset.yTrain.[batchStart..batchEnd-1]).toDouble()
         epochLoss <- epochLoss + loss.toScalar().toDouble()
         batchCount <- batchCount + 1
@@ -96,7 +96,7 @@ print("Evaluating model..")
 
 model.mode <- Mode.Eval
 
-let prediction = model.forward(dataset.xTest)
+let prediction = model(dataset.xTest)
 
 let evalMse = meanSquaredError(prediction, dataset.yTest).toScalar().toDouble()/double(dataset.numTestRecords)
 let evalMae = meanAbsoluteError(prediction, dataset.yTest).toDouble()/double(dataset.numTestRecords)

--- a/Examples/Regression-BostonHousing/main.fsx
+++ b/Examples/Regression-BostonHousing/main.fsx
@@ -19,86 +19,58 @@
 open Datasets
 open DiffSharp
 open DiffSharp.Model
-open DiffSharp.Util
+open DiffSharp.Data
+
+// Defining default hyper parameters
+let batchSize = 50
+let numEpochs = 200
+let learningRate = 0.0001
+let sizeHidden1 = 100
+let sizeHidden2 = 50
+let sizeHidden3 = 10
+let sizeHidden4 = 1
+
 
 // open Dataset
 let dataset = BostonHousing()
+let trainIter = DataLoader(TensorDataset(dataset.xTrain,dataset.yTrain),batchSize=batchSize, shuffle = true)
 
 // Create Model
 type RegressionModel() = 
     inherit Model()
-    let layer1 = Linear(inFeatures=13, outFeatures=64) --> dsharp.relu
-    let layer2 = Linear(inFeatures=64, outFeatures=32) --> dsharp.relu
-    let layer3 = Linear(inFeatures=32, outFeatures=1)
+    let layer1 = Linear(inFeatures=13, outFeatures=sizeHidden1) --> dsharp.relu
+    let layer2 = Linear(inFeatures=sizeHidden1, outFeatures=sizeHidden2) --> dsharp.relu
+    let layer3 = Linear(inFeatures=sizeHidden2, outFeatures=sizeHidden3) --> dsharp.relu
+    let layer4 = Linear(inFeatures=sizeHidden3,outFeatures=sizeHidden4)
     
-    do base.register()
+    do base.add([layer1;layer2;layer3;layer4],
+                ["layer1";"layer2";"layer3";"layer4"])
     override _.forward(input) =
-        input |> layer1.forward |> layer2.forward |> layer3.forward
+        input |> layer1.forward |> layer2.forward |> layer3.forward |> layer4.forward
 
 let model = RegressionModel()
-
-// Train Model
-let optimizer = RMSProp(model, learningRate=dsharp.scalar 0.001)
 model.mode <- Mode.Train
 
-let epochCount = 500
-let batchSize = 32
-let numberOfBatch = int(ceil(double(dataset.numTrainRecords) / double(batchSize)))
-let shuffle = true
+let criterion (outputs, labels) = dsharp.mseLoss(outputs,labels)
+// Train Model
+let optimizer = Optim.SGD(model, learningRate= dsharp.scalar learningRate)
 
-let meanAbsoluteError(predictions: Tensor, truths: Tensor) =
-    abs(predictions - truths).mean().toScalar()
-let meanSquaredError(predicted: Tensor, expected: Tensor) =
-    (predicted - expected) |> fun error -> (error * error).mean()
+for epoch in 1..numEpochs do
+    let mutable runningLoss = 0.0
+    for _batch, inputs, labels in trainIter.epoch() do
+        model.reverseDiff()
+        // forward pass
+        let outputs = model.forward(inputs)
+        // defining loss
+        let loss = criterion(outputs,labels)
+        // computing gradients
+        loss.reverse()
+        // accumulating running loss
+        runningLoss <- runningLoss + loss.toDouble()
+        // updated weights based on computed gradients
+        optimizer.step()
+    if epoch % 20 = 0 then
+        printfn $"Epoch {epoch}/{numEpochs} running accumulative loss across all batches: %.3f{runningLoss}"
 
-
-printfn("Starting training..")
-
-for epoch in 1..epochCount do
-    let mutable epochLoss: double = 0.0
-    let mutable epochMAE: double = 0.0
-    let mutable batchCount: int = 0
-    let batchArray = Array.replicate numberOfBatch false
-    for batch in 0..numberOfBatch-1 do
-        let mutable r = batch
-        if shuffle then
-            let mutable continueLooping = true
-            while continueLooping do
-                r <- Random.Integer(0,numberOfBatch-1)
-                if not batchArray.[r] then
-                    batchArray.[r] <- true
-                    continueLooping <- false
-
-        let batchStart = r * batchSize
-        let batchEnd = min dataset.numTrainRecords (batchStart + batchSize)
-        let (loss, grad) = valueWithGradient<| fun model -> =  (model: RegressionModel) = Tensor in
-            let logits = model(dataset.xTrain[batchStart..<batchEnd])
-            meanSquaredError(predicted=logits, expected=dataset.yTrain[batchStart..<batchEnd])
-
-        optimizer.update(&model, along=grad)
-        
-        let logits = model(dataset.xTrain.[batchStart..batchEnd-1])
-        epochMAE <- epochMAE + meanAbsoluteError(logits, dataset.yTrain.[batchStart..batchEnd-1]).toDouble()
-        epochLoss <- epochLoss + loss.toScalar().toDouble()
-        batchCount <- batchCount + 1
-
-    epochMAE <-  epochMAE / double(batchCount)
-    epochLoss <- epochLoss / double(batchCount)
-
-    if epoch = epochCount-1 then
-        printfn $"MSE: {epochLoss}, MAE: {epochMAE}, Epoch: {epoch+1}"
-
-
-
-// Evaluate Model
-
-print("Evaluating model..")
-
-model.mode <- Mode.Eval
-
-let prediction = model(dataset.xTest)
-
-let evalMse = meanSquaredError(prediction, dataset.yTest).toScalar().toDouble()/double(dataset.numTestRecords)
-let evalMae = meanAbsoluteError(prediction, dataset.yTest).toDouble()/double(dataset.numTestRecords)
-
-print($"MSE: {evalMse}, MAE: {evalMae}")
+let outputs = model.forward(dataset.xTest)
+let err = sqrt(dsharp.mseLoss(outputs,dataset.yTest))

--- a/Library/Datasets/DatasetUtilities.fs
+++ b/Library/Datasets/DatasetUtilities.fs
@@ -28,7 +28,7 @@ type DatasetUtilities() =
         let extract = defaultArg extract true
         if not extract then 
             use wc = new WebClient()
-            wc.DownloadFile(remoteRoot, localFileName)
+            wc.DownloadFile(Uri(remoteRoot,filename), localFileName)
         else
             failwith "TBD" // let r = new BinaryReader(new GZipStream(File.Open(filename, FileMode.Open, FileAccess.Read, FileShare.Read), CompressionMode.Decompress))
         localFileName


### PR DESCRIPTION
This example uses DiffSharp idioms to replicate code from this [captum pytorch example](https://captum.ai/tutorials/House_Prices_Regression_Interpret). It seems to work. 

This pull request also includes commits from my other pull request that are necessary to get the data loading working. If you accept this pull request, we can close the other pull request.

I know the original comes from tensorflow/swift; if the goal is to keep it replicating the tensorflow api eventually, feel free to ignore this.